### PR TITLE
Remove unused pthiter declaration

### DIFF
--- a/src/controller-plan/TerminCreator.cpp
+++ b/src/controller-plan/TerminCreator.cpp
@@ -261,7 +261,6 @@ void TerminCreator::addTGruppen(std::vector<TGruppe*>* tglist, std::vector<PTerm
 	for (std::vector<TGruppe*>::iterator tgiter = tglist->begin(); tgiter != tglist->end(); tgiter++) {
 		if ((**tgiter).list_serie.empty()) {
 			//alle Termine der TGruppe bilden eine PTGruppe
-			std::vector<PTerminHolder>::iterator pthiter = pthlist->begin();
 			std::vector<PTermin*> current_list;
 			for (std::vector<PTerminHolder>::iterator pthiter = pthlist->begin(); pthiter != pthlist->end(); pthiter++) {
 				if (std::find((**tgiter).list_einzel.begin(), (**tgiter).list_einzel.end(), pthiter->e) != (**tgiter).list_einzel.end()) {


### PR DESCRIPTION
This resolves the following warning:
```
Compiling C++ object 'miniplane..._controller-plan_TerminCreator.cpp.o'.
../src/controller-plan/TerminCreator.cpp: In function ‘void TerminCreator::addTGruppen(std::vector<TGruppe*>*, std::vector<TerminCreator::PTerminHolder>*)’:
../src/controller-plan/TerminCreator.cpp:264:41: warning: variable ‘pthiter’ set but not used [-Wunused-but-set-variable]
  264 |    std::vector<PTerminHolder>::iterator pthiter = pthlist->begin();
      |                                         ^~~~~~~
```
In all inner scopes where `pthiter` could be used, `pthiter` is being redeclared.