### PR TITLE
Default to english

### DIFF
--- a/src/file/DataFileHandler.cpp
+++ b/src/file/DataFileHandler.cpp
@@ -129,7 +129,7 @@ void DataFileHandler::loadSettings() {
 				|| lang == wxLANGUAGE_GERMAN_SWISS) {
 			R::lang = R::LANG_DE;
 		} else {
-			R::lang = R::LANG_DE; //until language selectable
+			R::lang = R::LANG_EN; //until language selectable
 		}
 	}
 	file.Close();


### PR DESCRIPTION
This changes the default language to english. When a german system locale is detected we still use german.

Without this change on english systems german is still the default.

What do you think?