### PR TITLE
Add VERSIONINFO resource

### DIFF
--- a/res/versioninfo.rc
+++ b/res/versioninfo.rc
@@ -1,0 +1,35 @@
+#pragma code_page(65001)  // UTF-8
+
+#include <windows.h>
+
+#define VER_VERSION     2,0,4,0
+#define VER_VERSION_STR "2.0.4"
+#define VER_NAME_STR    "MiniPlaner"
+
+VS_VERSION_INFO VERSIONINFO
+FILEVERSION     VER_VERSION
+PRODUCTVERSION  VER_VERSION
+FILEOS          VOS_NT_WINDOWS32
+FILETYPE        VFT_APP
+{
+    BLOCK "StringFileInfo"
+    {
+        BLOCK "040904B0"  // en_US.UTF-8
+        {
+            VALUE "CompanyName",      "Yannik Schälte"
+            VALUE "FileDescription",  VER_NAME_STR
+            VALUE "FileVersion",      VER_VERSION_STR
+            VALUE "InternalName",     VER_NAME_STR
+            VALUE "LegalCopyright",   "©Yannik Schälte; available under the LGPL-3.0"
+            VALUE "OriginalFilename", "miniplaner.exe"
+            VALUE "ProductName",      VER_NAME_STR
+            VALUE "ProductVersion",   VER_VERSION_STR
+        }
+    }
+
+    BLOCK "VarFileInfo"
+    BEGIN
+        VALUE "Translation", 0x0409, 0x04B0,  // en_US.UTF-8
+                             0x0407, 0x04B0   // de_DE.UTF-8
+    }
+}


### PR DESCRIPTION
This adds the [VERSIONINFO resource](https://docs.microsoft.com/en-us/windows/win32/menurc/versioninfo-resource) to the windows resources, similar to those present in the binary distribution of 2.0.4.

What do you think?