### PR TITLE
Remove unused field 'selectedCol'

### DIFF
--- a/src/view-data/MinisPanel.cpp
+++ b/src/view-data/MinisPanel.cpp
@@ -150,17 +150,6 @@ void MinisPanel::onLIKey(wxListEvent& evt) {
 		}
 	}
 }
-/**
-void MinisPanel::onColClick(wxListEvent& evt) {
-	int col = evt.GetColumn();
-	if (col != 3 && col != 6) {
-		wxString Messdiener::* list[] = {&Messdiener::name, &Messdiener::vorname};
-		sortByString(col == selectedCol, &Messdiener::name);
-	} else if (col == 3) {
-
-	}
-	selectedCol = col;
-}**/
 
 void MinisPanel::sortByString(bool inc, wxString Messdiener::* var) {
 	if (inc) {

--- a/src/view-data/MinisPanel.h
+++ b/src/view-data/MinisPanel.h
@@ -23,7 +23,6 @@ private:
 	App* app;
 	
 	std::vector<Messdiener*> shownMinis;
-	int selectedCol = -1;
 	void sortByString(bool inc, wxString Messdiener::* var);
 	
 	wxBoxSizer* sizer;


### PR DESCRIPTION
Compilation with clang on macOS (from #41) gave the following warning:
```
 In file included from ../src/view-data/MinisPanel.cpp:8:
../src/view-data/../view/../view-data/MinisPanel.h:26:6: warning: private field 'selectedCol' is not used [-Wunused-private-field]
        int selectedCol = -1;
            ^
1 warning generated.
```

Shall we just clean up the code as proposed here or reimplement the function?