### PR TITLE
Fixup: Set correct license in meson.build

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -1,5 +1,5 @@
 project('MiniPlaner', 'cpp',
-    license : 'GPL3',
+    license : 'LGPL3',
     version : '2.0.4',
     default_options : ['cpp_std=c++11']
 )


### PR DESCRIPTION
There is a typo in the license in meson.build.