### PR TITLE
Introduce generated config.h

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -4,6 +4,28 @@ project('MiniPlaner', 'cpp',
     default_options : ['cpp_std=c++11']
 )
 
+wx_dep = dependency('wxwidgets', version : '>=3.0.4')
+
+conf_data = configuration_data()
+conf_data.set('name', meson.project_name())
+conf_data.set('license', ', '.join(meson.project_license()))
+conf_data.set('version', meson.project_version())
+version_array = meson.project_version().split('.')
+version_array_4 = [
+    version_array[0],
+    version_array[1],
+    version_array[2],
+    version_array.get(3, '0')
+]
+conf_data.set('version_bin', ','.join(version_array_4))
+cpp_compiler = meson.get_compiler('cpp')
+conf_data.set('compiler', cpp_compiler.get_id() + ' ' + cpp_compiler.version())
+conf_data.set('wx_dep', 'WxWidgets ' + wx_dep.version())
+configure_file(input : 'src/config.h.in',
+               output : 'config.h',
+               configuration : conf_data)
+
+miniplaner_inc = include_directories('.')
 miniplaner_src = files(
     'src/App.cpp',
     'src/MiniPlaner.cpp',
@@ -65,10 +87,9 @@ miniplaner_src = files(
     'src/view/MainFrame.cpp'
 )
 
-wx_dep = dependency('wxwidgets', version : '>=3.0.4')
-
 if host_machine.system() == 'windows'
     res_inc = include_directories(
+        '.',
         'src/img'
     )
     res_dep_files = files(
@@ -90,6 +111,7 @@ if host_machine.system() == 'windows'
 endif
 
 executable('miniplaner', miniplaner_src,
+  include_directories : miniplaner_inc,
   dependencies : [wx_dep],
   install : true
 )

--- a/res/versioninfo.rc
+++ b/res/versioninfo.rc
@@ -2,13 +2,11 @@
 
 #include <windows.h>
 
-#define VER_VERSION     2,0,4,0
-#define VER_VERSION_STR "2.0.4"
-#define VER_NAME_STR    "MiniPlaner"
+#include <config.h>
 
 VS_VERSION_INFO VERSIONINFO
-FILEVERSION     VER_VERSION
-PRODUCTVERSION  VER_VERSION
+FILEVERSION     VERSION_BIN
+PRODUCTVERSION  VERSION_BIN
 FILEOS          VOS_NT_WINDOWS32
 FILETYPE        VFT_APP
 {
@@ -16,14 +14,14 @@ FILETYPE        VFT_APP
     {
         BLOCK "040904B0"  // en_US.UTF-8
         {
-            VALUE "CompanyName",      "Yannik Schälte"
-            VALUE "FileDescription",  VER_NAME_STR
-            VALUE "FileVersion",      VER_VERSION_STR
-            VALUE "InternalName",     VER_NAME_STR
-            VALUE "LegalCopyright",   "©Yannik Schälte; available under the LGPL-3.0"
+            VALUE "CompanyName",      AUTHOR_STR
+            VALUE "FileDescription",  NAME_STR
+            VALUE "FileVersion",      VERSION_STR
+            VALUE "InternalName",     NAME_STR
+            VALUE "LegalCopyright",   COPYRIGHT_STR
             VALUE "OriginalFilename", "miniplaner.exe"
-            VALUE "ProductName",      VER_NAME_STR
-            VALUE "ProductVersion",   VER_VERSION_STR
+            VALUE "ProductName",      NAME_STR
+            VALUE "ProductVersion",   VERSION_STR
         }
     }
 

--- a/src/R.cpp
+++ b/src/R.cpp
@@ -185,6 +185,7 @@ wxString R::KOPIERTWARNICHTMOEGLICH = wxT("\nBei folgenden Minis war dies nicht 
 //Über
 wxString R::HEADLINE = wxT("ein Programm zum effizienten Erstellen hochwertiger Ministrantenpläne");
 wxString R::AUTOR = wxT("Autor: ");
+wxString R::BEITRAGENDE = wxT("Beitragende: ");
 wxString R::KOMPILIERTMIT = wxT("Kompiliert mit: ");
 wxString R::BIBLIOTHEKEN = wxT("Bibliotheken: ");
 wxString R::INSTALLATIONSVERZEICHNIS = wxT("Installationsverzeichnis: ");
@@ -426,6 +427,7 @@ void R::setLangEN() {
 	//Über
 	R::HEADLINE = wxT("a small program to efficiently create high-quality service plans");
 	R::AUTOR = wxT("Author: ");
+	R::BEITRAGENDE = wxT("Contributors: ");
 	R::KOMPILIERTMIT = wxT("Compiled with: ");
 	R::BIBLIOTHEKEN = wxT("Libraries: ");
 	R::INSTALLATIONSVERZEICHNIS = wxT("Installation directory: ");

--- a/src/R.cpp
+++ b/src/R.cpp
@@ -473,7 +473,6 @@ void R::setSubWindowPosition(wxWindow* parent, wxDialog* self) {
 	self->SetPosition(wxPoint(parent_point.x + parent_size.x - own_size.x - 150, parent_point.y + 30));
 }
 
-const wxString R::VERSION_ID = wxT("2.0.4");
 const int R::VERSION_NUMBER = 4;//need number for comparison
 
 wxString R::window_size = wxT("");

--- a/src/R.cpp
+++ b/src/R.cpp
@@ -187,7 +187,6 @@ wxString R::HEADLINE = wxT("ein Programm zum effizienten Erstellen hochwertiger 
 wxString R::AUTOR = wxT("Autor: ");
 wxString R::KOMPILIERTMIT = wxT("Kompiliert mit: ");
 wxString R::BIBLIOTHEKEN = wxT("Bibliotheken: ");
-wxString R::BUILDDATUM = wxT("Build-Datum: ");
 wxString R::INSTALLATIONSVERZEICHNIS = wxT("Installationsverzeichnis: ");
 //Einstellungen
 wxString R::MSG_LANG_CHANGE_DE = wxT("(Änderung erst bei Programm-Neustart wirksam)");
@@ -429,7 +428,6 @@ void R::setLangEN() {
 	R::AUTOR = wxT("Author: ");
 	R::KOMPILIERTMIT = wxT("Compiled with: ");
 	R::BIBLIOTHEKEN = wxT("Libraries: ");
-	R::BUILDDATUM = wxT("Build date: ");
 	R::INSTALLATIONSVERZEICHNIS = wxT("Installation directory: ");
 
 	//Einstellungen
@@ -477,6 +475,5 @@ void R::setSubWindowPosition(wxWindow* parent, wxDialog* self) {
 
 const wxString R::VERSION_ID = wxT("2.0.4");
 const int R::VERSION_NUMBER = 4;//need number for comparison
-const wxString R::BUILDDATUM_DATE = wxT("01.03.2019");
 
 wxString R::window_size = wxT("");

--- a/src/R.h
+++ b/src/R.h
@@ -193,6 +193,7 @@ namespace R {
 	//Über
 	extern wxString HEADLINE;
 	extern wxString AUTOR;
+	extern wxString BEITRAGENDE;
 	extern wxString KOMPILIERTMIT;
 	extern wxString BIBLIOTHEKEN;
 	extern wxString INSTALLATIONSVERZEICHNIS;

--- a/src/R.h
+++ b/src/R.h
@@ -258,7 +258,6 @@ namespace R {
 
 	void setSubWindowPosition(wxWindow* parent, wxDialog* self);
 
-	extern const wxString VERSION_ID;
 	extern const int VERSION_NUMBER;//need number for comparison
 
 	extern wxString window_size;

--- a/src/R.h
+++ b/src/R.h
@@ -195,7 +195,6 @@ namespace R {
 	extern wxString AUTOR;
 	extern wxString KOMPILIERTMIT;
 	extern wxString BIBLIOTHEKEN;
-	extern wxString BUILDDATUM;
 	extern wxString INSTALLATIONSVERZEICHNIS;
 	//Einstellungen
 	extern wxString MSG_LANG_CHANGE_EN;
@@ -261,7 +260,6 @@ namespace R {
 
 	extern const wxString VERSION_ID;
 	extern const int VERSION_NUMBER;//need number for comparison
-	extern const wxString BUILDDATUM_DATE;
 
 	extern wxString window_size;
 };

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,9 @@
+#pragma once
+
+#define NAME_STR "@name@"
+#define AUTHOR_STR "Yannik Schälte"
+#define COPYRIGHT_STR "©" AUTHOR_STR "; available under @license@"
+#define VERSION_STR "@version@"
+#define VERSION_BIN @version_bin@
+#define COMPILER_STR "@compiler@"
+#define WX_DEP_STR "@wx_dep@"

--- a/src/update/UpdateChecker.cpp
+++ b/src/update/UpdateChecker.cpp
@@ -8,6 +8,7 @@
 #include "UpdateChecker.h"
 #include <wx/utils.h>
 #include <wx/sstream.h>
+#include <config.h>
 #include "../R.h"
 
 void UpdateChecker::checkUpdate(wxWindow* parent) {
@@ -18,7 +19,7 @@ void UpdateChecker::checkUpdate(wxWindow* parent) {
 		if (in && in->IsOk()) {
 			wxStringOutputStream html_stream(&htmlData);
 			in->Read(html_stream);
-			if (!htmlData.IsSameAs(R::VERSION_ID)) {
+			if (!htmlData.IsSameAs(wxT(VERSION_STR))) {
 				UpdateDialog dialog(parent);
 				dialog.ShowModal();
 			}

--- a/src/view/AboutPanel.cpp
+++ b/src/view/AboutPanel.cpp
@@ -48,6 +48,8 @@ AboutPanel::AboutPanel(wxWindow* parent)
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("yannik.schaelte@gmail.com")), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("Homepage: ")), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("https://yannikschaelte.github.io/MiniPlaner/")), 0, wxALL, 2);
+	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::BEITRAGENDE), 0, wxALL, 2);
+	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("Yannik Schälte, Martin Kröning")), 0, wxALL, 2);
 	sizer_2->AddSpacer(10);
 	sizer_2->AddSpacer(10);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::KOMPILIERTMIT), 0, wxALL, 2);

--- a/src/view/AboutPanel.cpp
+++ b/src/view/AboutPanel.cpp
@@ -7,9 +7,11 @@
 
 #include "AboutPanel.h"
 #include <wx/generic/statbmpg.h>
+#include <wx/hyperlink.h>
 #include <wx/stdpaths.h>
 #include <wx/filename.h>
 #include <wx/image.h>
+#include <config.h>
 #include "../img/minis.xpm"
 #include "../R.h"
 #include "../Util.h"
@@ -30,20 +32,20 @@ AboutPanel::AboutPanel(wxWindow* parent)
 	wxStaticBitmap* sb_icon = new wxStaticBitmap(this, R::ID_ANY, bitmap);
 	sizer_1->Add(sb_icon, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 	wxBoxSizer* sizer_1_r = new wxBoxSizer(wxVERTICAL);
-	wxStaticText* st_name = new wxStaticText(this, R::ID_ANY, wxT("MiniPlaner"));
+	wxStaticText* st_name = new wxStaticText(this, R::ID_ANY, wxT(NAME_STR));
 	st_name->SetFont(st_name->GetFont().Bold());
 	sizer_1_r->Add(st_name, 0, wxALL, 1);
 	wxStaticText* st_desc = new wxStaticText(this, R::ID_ANY, R::HEADLINE);
 	sizer_1_r->Add(st_desc, 0, wxALL, 1);
-	sizer_1_r->Add(new wxStaticText(this, R::ID_ANY, wxT("\x24B8 Yannik Schälte")), 0, wxALL, 1);
+	sizer_1_r->Add(new wxStaticText(this, R::ID_ANY, wxT(COPYRIGHT_STR)), 0, wxALL, 1);
 	sizer_1->Add(sizer_1_r, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 	sizer->Add(sizer_1, 0, wxEXPAND | wxALL, 10);
 
 	wxFlexGridSizer* sizer_2 = new wxFlexGridSizer(10, 2, 0, 0);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("Version: ")), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::VERSION_ID), 0, wxALL, 2);
+	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT(VERSION_STR)), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::AUTOR), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("Yannik Schälte")), 0, wxALL, 2);
+	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT(AUTHOR_STR)), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("E-Mail: ")), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("yannik.schaelte@gmail.com")), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("Homepage: ")), 0, wxALL, 2);
@@ -51,9 +53,9 @@ AboutPanel::AboutPanel(wxWindow* parent)
 	sizer_2->AddSpacer(10);
 	sizer_2->AddSpacer(10);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::KOMPILIERTMIT), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("mingw32 4.8.1-4")), 0, wxALL, 2);
+	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT(COMPILER_STR)), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::BIBLIOTHEKEN), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("wxWidgets 3.0.2 (unicode, static)")), 0, wxALL, 2);
+	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT(WX_DEP_STR)), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::INSTALLATIONSVERZEICHNIS), 0, wxALL, 2);
 	wxFileName file(wxStandardPaths::Get().GetExecutablePath());
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, file.GetPath()), 0, wxALL, 2);

--- a/src/view/AboutPanel.cpp
+++ b/src/view/AboutPanel.cpp
@@ -54,8 +54,6 @@ AboutPanel::AboutPanel(wxWindow* parent)
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("mingw32 4.8.1-4")), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::BIBLIOTHEKEN), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("wxWidgets 3.0.2 (unicode, static)")), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::BUILDDATUM), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::BUILDDATUM_DATE), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::INSTALLATIONSVERZEICHNIS), 0, wxALL, 2);
 	wxFileName file(wxStandardPaths::Get().GetExecutablePath());
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, file.GetPath()), 0, wxALL, 2);

--- a/src/view/AboutPanel.cpp
+++ b/src/view/AboutPanel.cpp
@@ -32,7 +32,7 @@ AboutPanel::AboutPanel(wxWindow* parent)
 	wxStaticBitmap* sb_icon = new wxStaticBitmap(this, R::ID_ANY, bitmap);
 	sizer_1->Add(sb_icon, 0, wxALL | wxALIGN_CENTER_VERTICAL, 5);
 	wxBoxSizer* sizer_1_r = new wxBoxSizer(wxVERTICAL);
-	wxStaticText* st_name = new wxStaticText(this, R::ID_ANY, wxT(NAME_STR));
+	wxStaticText* st_name = new wxStaticText(this, R::ID_ANY, wxT(NAME_STR " " VERSION_STR));
 	st_name->SetFont(st_name->GetFont().Bold());
 	sizer_1_r->Add(st_name, 0, wxALL, 1);
 	wxStaticText* st_desc = new wxStaticText(this, R::ID_ANY, R::HEADLINE);
@@ -42,8 +42,6 @@ AboutPanel::AboutPanel(wxWindow* parent)
 	sizer->Add(sizer_1, 0, wxEXPAND | wxALL, 10);
 
 	wxFlexGridSizer* sizer_2 = new wxFlexGridSizer(10, 2, 0, 0);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("Version: ")), 0, wxALL, 2);
-	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT(VERSION_STR)), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, R::AUTOR), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT(AUTHOR_STR)), 0, wxALL, 2);
 	sizer_2->Add(new wxStaticText(this, R::ID_ANY, wxT("E-Mail: ")), 0, wxALL, 2);


### PR DESCRIPTION
Resolves #33.

This removes the build time from being saved in the build for reproducibility, introduces `config.h` which is being generated from `config.h.in` by meson and includes a few opinionated rearrangements to `AboutPanel`:
Before:
![Screenshot from 2020-04-25 19-58-59](https://user-images.githubusercontent.com/28776973/80287051-7ab33900-872f-11ea-92ff-79e61e033f4a.png)
After:
![Screenshot from 2020-04-25 19-59-56](https://user-images.githubusercontent.com/28776973/80287058-80a91a00-872f-11ea-9207-054cfeab9b1d.png)

Are you okay with the rearrangements or would you rather have version and email as separate row?

Note: Its possible to use [wxHyperlinkCtrl](https://docs.wxwidgets.org/trunk/classwx_hyperlink_ctrl.html) to make hyperlinks (homepage and email) clickable, but that's not a drop-in since the spacing is different from wxStaticText, so that might be interesting in the future.