### PR TITLE
Explicitly specify PlanFileHandler::RES and D

### DIFF
--- a/src/file/PlanFileHandler.cpp
+++ b/src/file/PlanFileHandler.cpp
@@ -13,8 +13,8 @@
 #include "DataFileHandler.h"
 #include "../Util.h"
 
-const wxString PlanFileHandler::RES = DataFileHandler::RES;
-const wxString PlanFileHandler::D = DataFileHandler::D;
+const wxString PlanFileHandler::RES = wxT("res");
+const wxString PlanFileHandler::D = wxT("\t");
 const wxString PlanFileHandler::DIENSTEFILE = wxT("/dienste.dat");
 const wxString PlanFileHandler::MINISFILE = wxT("/minis.dat");
 const wxString PlanFileHandler::TERMINEFILE = wxT("/termine.dat");


### PR DESCRIPTION
Resolves #48.

It turns out that both `PlanFileHandler::RES` and `PlanFileHandler::D` are empty strings on Windows.

I don't know what the problem is, but this workaround fixes the issue just fine.

What do you think?