### PR TITLE
Don't use hardcoded colours

### DIFF
--- a/src/view-plan/PlanPlanerDialog.cpp
+++ b/src/view-plan/PlanPlanerDialog.cpp
@@ -119,7 +119,6 @@ void PlanPlanerDialog::initComponents() {
 	wxBoxSizer* sizer_maske_wrap = new wxBoxSizer(wxVERTICAL);
 	sizer_maske_wrap->Add(sizer_maske, 1, wxEXPAND | wxALL, 10);
 	pl_maske->SetSizer(sizer_maske_wrap);
-	pl_maske->SetBackgroundColour(*wxWHITE);
 	nb_termine->InsertPage(0, pl_maske, R::MASKE);
 
 	//Vorschau
@@ -140,7 +139,6 @@ void PlanPlanerDialog::initComponents() {
 	bt_options = new wxButton(pl_r, R::ID_BT_EDT2, R::EINSTELLUNGEN);
 	sizer_r->Add(bt_options, 0, wxEXPAND, 0);
 	bt_compute = new wxButton(pl_r, R::ID_BT_COMPUTE, R::AUTOMATISCH);
-	bt_compute->SetBackgroundColour(wxColour(225, 255, 164, 255));
 	sizer_r->Add(bt_compute, 0, wxEXPAND, 0);
 	bt_stop = new wxButton(pl_r, R::ID_BT_STOP, R::STOPPEN);
 	bt_stop->Disable();
@@ -567,7 +565,9 @@ void PlanPlanerDialog::onShowPMiniChoiceDialog(wxMouseEvent& evt) {
 void PlanPlanerDialog::highlightPMiniChoiceDialog(PTermin* termin, int dienst, int mini_i) {
 	PMessdiener* mini = termin->list_dienst_minis.at(dienst).second.at(mini_i);
 	highlight(mini);
+	tview_choices.at(termin->_id).at(dienst).at(mini_i)->SetForegroundColour(colour_highlighttext);
 	tview_choices.at(termin->_id).at(dienst).at(mini_i)->SetBackgroundColour(colour_selection);
+	tview_pls.at(termin->_id).at(dienst).at(mini_i)->SetForegroundColour(colour_highlighttext);
 	tview_pls.at(termin->_id).at(dienst).at(mini_i)->SetBackgroundColour(colour_selection);
 	tview_pls.at(termin->_id).at(dienst).at(mini_i)->Refresh();
 }
@@ -586,7 +586,9 @@ void PlanPlanerDialog::unHighlight() {
 		for (int j = 0; j < num_dienste; j++) {
 			int num_einsaetze = tview_choices.at(i).at(j).size();
 			for (int k = 0; k < num_einsaetze; k++) {
+				tview_choices.at(i).at(j).at(k)->SetForegroundColour(colour_default);
 				tview_choices.at(i).at(j).at(k)->SetBackgroundColour(colour_default);
+				tview_pls.at(i).at(j).at(k)->SetForegroundColour(colour_default);
 				tview_pls.at(i).at(j).at(k)->SetBackgroundColour(colour_default);
 				tview_pls.at(i).at(j).at(k)->Refresh();
 			}
@@ -610,11 +612,15 @@ void PlanPlanerDialog::highlight(PMessdiener* mini) {
 				int num_einsaetze = tview_choices.at(i).at(j).size();
 				for (int k = 0; k < num_einsaetze; k++) {
 					if (mini == controller->planer->list_termin.at(i)->list_dienst_minis.at(j).second.at(k)) {
+						tview_choices.at(i).at(j).at(k)->SetForegroundColour(colour_highlighttext);
 						tview_choices.at(i).at(j).at(k)->SetBackgroundColour(colour_highlight);
+						tview_pls.at(i).at(j).at(k)->SetForegroundColour(colour_highlighttext);
 						tview_pls.at(i).at(j).at(k)->SetBackgroundColour(colour_highlight);
 						tview_pls.at(i).at(j).at(k)->Refresh();
 					} else {
+						tview_choices.at(i).at(j).at(k)->SetForegroundColour(colour_default);
 						tview_choices.at(i).at(j).at(k)->SetBackgroundColour(colour_default);
+						tview_pls.at(i).at(j).at(k)->SetForegroundColour(colour_default);
 						tview_pls.at(i).at(j).at(k)->SetBackgroundColour(colour_default);
 						tview_pls.at(i).at(j).at(k)->Refresh();
 					}

--- a/src/view-plan/PlanPlanerDialog.h
+++ b/src/view-plan/PlanPlanerDialog.h
@@ -57,9 +57,10 @@ private:
 	std::vector<std::vector<std::vector<wxPanel*> > > tview_pls;
 	PMessdiener* tview_mini_high = NULL;
 	bool continueComputation = false;
-	const wxColour colour_default = *wxWHITE;
-	const wxColour colour_highlight = wxColour(255, 255, 153, 255);
-	const wxColour colour_selection = wxColour(255, 230, 130, 255);
+	const wxColour colour_default = wxNullColour;
+	const wxColour colour_highlight = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT);
+	const wxColour colour_highlighttext = wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT);
+	const wxColour colour_selection = wxSystemSettings::GetColour(wxSYS_COLOUR_GRAYTEXT);
 
 	wxListView* lv_minis;
 	wxListView* lv_mgruppen;

--- a/src/view/AboutPanel.cpp
+++ b/src/view/AboutPanel.cpp
@@ -15,7 +15,6 @@
 
 AboutPanel::AboutPanel(wxWindow* parent)
 : wxPanel(parent, R::ID_ANY) {
-	SetBackgroundColour(*wxWHITE);
 	wxBoxSizer* sizer = new wxBoxSizer(wxVERTICAL);
 
 	wxBoxSizer* sizer_1 = new wxBoxSizer(wxHORIZONTAL);

--- a/src/view/MainFrame.cpp
+++ b/src/view/MainFrame.cpp
@@ -200,11 +200,9 @@ void MainFrame::handleLBSel(int index) {
 		list_pls.at(i == 8 ? 7 : i)->Show(isSel);
 		if (isSel) {
 			list_tabs.at(i).first->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
-			list_tabs.at(i).second->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
 			list_tabs.at(i).second->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		} else {
 			list_tabs.at(i).first->SetBackgroundColour(wxNullColour);
-			list_tabs.at(i).second->SetBackgroundColour(wxNullColour);
 			list_tabs.at(i).second->SetForegroundColour(wxNullColour);
 		}
 		list_tabs.at(i).first->Refresh();

--- a/src/view/MainFrame.cpp
+++ b/src/view/MainFrame.cpp
@@ -32,7 +32,6 @@ MainFrame::MainFrame(App* _app)
 	wxBoxSizer* sizer = new wxBoxSizer(wxHORIZONTAL);
 
 	pl_tabs = new wxPanel(pl_bg, R::ID_ANY, wxDefaultPosition, wxDefaultSize, wxBORDER_NONE | wxTAB_TRAVERSAL);
-	pl_tabs->SetBackgroundColour(*wxWHITE);
 	wxBoxSizer* sizer_tabs = new wxBoxSizer(wxVERTICAL);
 
 	wxString list_names[9] = {R::DIENSTE, R::MINIS, R::MGRUPPEN, R::TERMINE, R::TGRUPPEN, R::FEHLZEITEN, R::PLAENE, R::HILFE, R::UEBER};
@@ -204,9 +203,9 @@ void MainFrame::handleLBSel(int index) {
 			list_tabs.at(i).second->SetBackgroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHT));
 			list_tabs.at(i).second->SetForegroundColour(wxSystemSettings::GetColour(wxSYS_COLOUR_HIGHLIGHTTEXT));
 		} else {
-			list_tabs.at(i).first->SetBackgroundColour(*wxWHITE);
-			list_tabs.at(i).second->SetBackgroundColour(*wxWHITE);
-			list_tabs.at(i).second->SetForegroundColour(*wxBLACK);
+			list_tabs.at(i).first->SetBackgroundColour(wxNullColour);
+			list_tabs.at(i).second->SetBackgroundColour(wxNullColour);
+			list_tabs.at(i).second->SetForegroundColour(wxNullColour);
 		}
 		list_tabs.at(i).first->Refresh();
 	}


### PR DESCRIPTION
Fixes #47.

This removes/replaces any colours which are hardcoded or incompatible with dark themes.

What do you think?

# Pictures

All pictures on Linux have been taken using GTK2.

Pictures on Windows have been taken with #49 merged.

## About

### Adwaita
Before:
![Screenshot from 2020-04-26 11-24-06](https://user-images.githubusercontent.com/28776973/80303588-7cbddc00-87b1-11ea-9229-4a874337610c.png)
After:
![Screenshot from 2020-04-26 11-27-51](https://user-images.githubusercontent.com/28776973/80303598-88a99e00-87b1-11ea-846a-138efbe79a6d.png)

### Adwaita-dark
Before:
![Screenshot from 2020-04-26 11-26-47](https://user-images.githubusercontent.com/28776973/80303616-9bbc6e00-87b1-11ea-9b15-d579fdc93780.png)
After:
![Screenshot from 2020-04-26 11-28-48](https://user-images.githubusercontent.com/28776973/80303622-a5de6c80-87b1-11ea-9529-492a9a870c53.png)

### Windows
Before:
![Annotation 2020-04-26 113814](https://user-images.githubusercontent.com/28776973/80303777-a0cded00-87b2-11ea-8d67-d8172cefb8df.png)
After:
![Annotation 2020-04-26 111918](https://user-images.githubusercontent.com/28776973/80303809-cd820480-87b2-11ea-92bf-bbf96f076a5f.png)


## PlanPlaner

### Adwaita
Before:
![Screenshot from 2020-04-26 11-25-59](https://user-images.githubusercontent.com/28776973/80304245-fb684880-87b4-11ea-9da4-45dbb442a6f7.png)
After:
![Screenshot from 2020-04-26 11-28-20](https://user-images.githubusercontent.com/28776973/80304274-1fc42500-87b5-11ea-8d05-e7c83751c353.png)

### Adwaita-dark
Before:
![Screenshot from 2020-04-26 11-30-58](https://user-images.githubusercontent.com/28776973/80304342-6154d000-87b5-11ea-9c9c-3c9cd1860e09.png)
After:
![Screenshot from 2020-04-26 11-29-14](https://user-images.githubusercontent.com/28776973/80304291-2eaad780-87b5-11ea-967c-9197a58f6a1a.png)

### Windows
Before:
![Screenshot_win10_2020-04-26_11:38:36](https://user-images.githubusercontent.com/28776973/80304318-408c7a80-87b5-11ea-9554-aafb5f6f8bd5.png)
After:
![Screenshot_win10_2020-04-26_11:36:46](https://user-images.githubusercontent.com/28776973/80304320-43876b00-87b5-11ea-80e8-1fe466690ba2.png)
